### PR TITLE
Add availability calculation to laundry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Before you call this helper, set the following local variables:
 - `allmachinesjson` - a JSON string of https://mysparkle.ca/machines.json
 - `address` - exact or partial address where the laundry machines are located
 - `cardnumber` - your laundry card number
+- `availability_wait_time_mins` - estimated time, in minutes, it takes for someone to retrieve their laundry after the cycle is done
 
 #### Output
 

--- a/sandbox/sandbox.tasker.parseSparkleLaundry.js
+++ b/sandbox/sandbox.tasker.parseSparkleLaundry.js
@@ -3,11 +3,15 @@ const taskerSandbox = require('../src/sandbox.tasker').default;
 
 const allMachines = require('./fixtures/laundryMachines.json');
 /* all local variables accessible from Tasker are strings */
+
+/* eslint-disable camelcase */
 const taskerLocalVariables = {
     cardnumber: '1234',
     allmachinesjson: JSON.stringify(allMachines),
+    availability_wait_time_mins: 5,
     address: '123 Fake Street'
 };
+/* eslint-enable camelcase */
 
 const currentScriptFilename = path.basename(__filename);
 const scriptFilenameToTest = currentScriptFilename.replace('sandbox.', '');


### PR DESCRIPTION
What
---

If a machine is available, the final cycle is complete. However, there is no tracking on when it became available. It may have become available a minute ago and we cannot expect the user to have retrieved their laundry in such a short period of time.

Solution
---

Add parameter to configure how long after a machine has become available to report that it's available to put laundry into.

Closes #8 